### PR TITLE
Feature: Handle non-mobile twitter urls on android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,9 @@
               <data
                       android:host="mobile.twitter.com"
                       android:pathPattern="/.*/status/.*"  />
+              <data
+                      android:host="twitter.com"
+                      android:pathPattern="/.*/status/.*"  />
           </intent-filter>
       </activity>
     </application>

--- a/app/utils.js
+++ b/app/utils.js
@@ -114,7 +114,7 @@ export const getScreen = (url)=>{
     const channelLinks = [BiliSpaceLinks.mobileSpaceUrl, TwitterLinks.mobileTwitterUserPageUrl]
     const postLinks = [BiliSpaceLinks.postPageUrl, BiliSpaceLinks.mobilePostPageUrl]
     const articleLinks = [BiliArticleLinks.articlePageUrl]
-    const postRegLinks = [TwitterLinks.mobileTweetPageRegexUrl]
+    const postRegLinks = [TwitterLinks.tweetPageRegexUrl, TwitterLinks.mobileTweetPageRegexUrl]
     for(let pattern of postRegLinks){
         if(pattern.test(url))return "FullPost"
     }


### PR DESCRIPTION
At the time, Collector is able to handle 'https://mobile.twitter.com' links on Android.
This PR adds a URL handler for 'https://twitter.com', allowing for posts shared through the 'https://twitter.com/status/' scheme to be opened inside Collector.