### PR TITLE
Feature: Added functionality to the share post button

### DIFF
--- a/app/components/post.js
+++ b/app/components/post.js
@@ -394,7 +394,14 @@ const Post = React.memo((props) => {
                                 }}>
                                     <FeatherIcon name={"bookmark"} size={20} color={"gray"} style={{marginLeft: 15}}/>
                                 </TouchableNativeFeedback>
-                                <FeatherIcon name={"share-2"} size={20} color={"gray"} style={{marginLeft: 10}}/>
+                                <TouchableNativeFeedback onPress={() => {
+                                    Share.open({
+                                        title: data.title,
+                                        url: props.url
+                                    })
+                                }}>
+                                    <FeatherIcon name={"share-2"} size={20} color={"gray"} style={{marginLeft: 10}}/>
+                                </TouchableNativeFeedback>
                                 <TouchableNativeFeedback onPress={() => {
                                     setDialogVisible2(true)
                                 }}>


### PR DESCRIPTION
At the moment, the 'share' button below posts inside Collector has no effect.
This PR adds functionality to it using `react-native-share` – the same way [sharing an image](https://github.com/InfinityLoop1309/Collector/blob/ced5c1b063b5e07d1f91f63508f3cefc2240ab91/app/components/post.js#L424) is already implemented.

Tested successfully for Twitter posts, but it uses the abstraction Collector offers and should therefor work with posts from any implemented platform.